### PR TITLE
Deny install on php7 beacuse of incompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"type":"vcs", "url":"https://github.com/ElectricMaxxx/phpcr-odm.git"}
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": "^5.3,>=5.3.3",
         "doctrine/common": "^2.4",
         "jackalope/jackalope-doctrine-dbal": "^1.0"
     },


### PR DESCRIPTION
Related to https://github.com/ElectricMaxxx/DoctrineOrmOdmAdapter/issues/40
It is still not compatible with PHP7, but at least it avoids wasting time by installing on wrong platform.