### PR TITLE
Revert "Deny install on php7 beacuse of incompatibility"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         {"type":"vcs", "url":"https://github.com/ElectricMaxxx/phpcr-odm.git"}
     ],
     "require": {
-        "php": "^5.3,>=5.3.3",
+        "php": ">=5.3.3",
         "doctrine/common": "^2.4",
         "jackalope/jackalope-doctrine-dbal": "^1.0"
     },


### PR DESCRIPTION
This reverts commit 63d3f7d21a35aecdce28898952ba139c26026d77.

Fixes https://github.com/ElectricMaxxx/DoctrineOrmOdmAdapter/issues/45 ?